### PR TITLE
benchmark BLAKE3 with multiple threads

### DIFF
--- a/blake3/main.rs
+++ b/blake3/main.rs
@@ -1,7 +1,7 @@
 fn main() -> std::io::Result<()> {
     let data: Vec<u8> = random_numbers()
         .flat_map(|it| it.to_le_bytes())
-        .take(64 * 1024)
+        .take(64 * 1024 * 1024)
         .collect();
     std::fs::write("./input.data", data.as_slice())?;
 
@@ -10,6 +10,9 @@ fn main() -> std::io::Result<()> {
 
     eprintln!("\nRust:");
     exec("cargo run -q --release --manifest-path ./rust/Cargo.toml --features=pure")?;
+
+    eprintln!("\nRust with threads:");
+    exec("cargo run -q --release --manifest-path ./rust/Cargo.toml --features=threading")?;
 
     eprintln!("\nRust + k12:");
     exec("cargo run -q --release --manifest-path ./rust/Cargo.toml --features=k12")?;

--- a/blake3/rust/Cargo.lock
+++ b/blake3/rust/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "blake3"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +38,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq 0.2.5",
  "digest",
+ "rayon",
 ]
 
 [[package]]
@@ -68,6 +75,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +152,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -110,12 +175,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "rust"
 version = "0.1.0"
 dependencies = [
  "blake3",
  "kangarootwelve_xkcp",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "subtle"

--- a/blake3/rust/Cargo.toml
+++ b/blake3/rust/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 
 
 [dependencies]
-blake3 = "1.3.3"
+blake3 = { version = "1.3.3", features = ["rayon"] }
 kangarootwelve_xkcp = "0.1.5"
 
 [features]
 k12 = []
 pure = ["blake3/pure"]
+threading = []

--- a/blake3/zig/main.zig
+++ b/blake3/zig/main.zig
@@ -9,12 +9,12 @@ pub fn main() !void {
     defer file.close();
 
     // Read the contents
-    const data = try file.readToEndAlloc(allocator, 64 * 1024);
+    const data = try file.readToEndAlloc(allocator, 64 * 1024 * 1024);
     defer allocator.free(data);
-    std.debug.assert(data.len == 64 * 1024);
+    std.debug.assert(data.len == 64 * 1024 * 1024);
 
     var res: u32 = 0;
-    const attempts = 100_000;
+    const attempts = 100;
     var i: usize = 0;
     var t = try std.time.Timer.start();
     while (i < attempts) : (i += 1) {


### PR DESCRIPTION
Not a real contribution, just playing around :) I saw these benchmarks linked in a Zig thread, and I figured I might toss in the multithreaded version just in case that's interesting. Multithreading only starts to help for inputs larger than ~1 MB. I've arbitrarily picked 64 MB, and reduced the attempts count to compensate.

I've also noticed that single-threaded BLAKE3 takes a pretty big performance hit going from 64 KB to 64 MB on my machine. Not sure why that is...